### PR TITLE
Add correct version of dplyr

### DIFF
--- a/init.R
+++ b/init.R
@@ -3,7 +3,7 @@
 # NOTE: this script is executed in the chroot context; check paths!
 
 r <- getOption('repos')
-r['CRAN'] <- 'http://cloud.r-project.org'
+r['CRAN'] <- 'https://mran.microsoft.com/snapshot/2021-01-30'
 options(repos=r)
 
 # ======================================================================
@@ -11,5 +11,5 @@ options(repos=r)
 # packages go here
 install.packages(c('dash', 'readr', 'here', 'ggthemes', 'remotes',
                    'tidyverse','plotly', 'lintr', 'spelling',
-                   'checkmate', 'testthat', 'devtools'))
+                   'checkmate', 'testthat', 'devtools', 'dplyr'))
 remotes::install_github('facultyai/dash-bootstrap-components@r-release')


### PR DESCRIPTION
- We have to freeze dplyr to 1.0.3 because 1.0.4 add changes to mutate that break functionality.  Switching to 'https://mran.microsoft.com/snapshot/2021-01-30'.